### PR TITLE
Add Google Auth creds json file to ignore files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ Dockerfile
 node_modules
 npm-debug.log
 dist
+gha-creds-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # Redis
 dump.rdb
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
Per documentation [here](https://github.com/google-github-actions/auth?tab=readme-ov-file#prerequisites), adding this line to .*ignore files is necessary for security purposes.